### PR TITLE
convert information content

### DIFF
--- a/phenopy/__main__.py
+++ b/phenopy/__main__.py
@@ -62,12 +62,12 @@ def score(query_hpo_file, records_file=None, query_name='SAMPLE', obo_file=None,
         exit(1)
 
     # load phenotypes to genes associations
-    terms_to_genes, genes_to_terms, annotations_count = load_p2g(
+    terms_to_genes, genes_to_terms, num_genes_annotated = load_p2g(
         pheno2genes_file, logger=logger)
 
     # load hpo network
     hpo_network = _load_hpo_network(
-        obo_file, terms_to_genes, annotations_count, custom_annotations_file)
+        obo_file, terms_to_genes, num_genes_annotated, custom_annotations_file)
 
     # create instance the scorer class
     scorer = Scorer(hpo_network)
@@ -170,12 +170,12 @@ def score_product(records_file, obo_file=None, pheno2genes_file=None, threads=1,
             exit(1)
 
     # load phenotypes to genes associations
-    terms_to_genes, _, annotations_count = load_p2g(
+    terms_to_genes, _, num_genes_annotated = load_p2g(
         pheno2genes_file, logger=logger)
 
     # load hpo network
     hpo_network = _load_hpo_network(
-        obo_file, terms_to_genes, annotations_count, custom_annotations_file)
+        obo_file, terms_to_genes, num_genes_annotated, custom_annotations_file)
 
     # try except
     records = read_records_file(records_file, no_parents, hpo_network, logger=logger)

--- a/phenopy/ic.py
+++ b/phenopy/ic.py
@@ -27,8 +27,10 @@ def calculate_information_content(hpo_id, hpo_network, terms_to_genes, num_genes
         # include this to avoid returning zero division warnings.
         # when comparing two different leaves whose LCA is "phenotypic abnormality", the right side of the equation:
         # alphaIC / (alphaIC / betaIC), would be 0.0 / (0.0 / 0.0)
-        if np.isinf(information_content) or np.isnan(information_content):
+        if np.isnan(information_content):
             return np.nextafter(0, 1)
+        elif np.isinf(information_content):
+            return -np.log(np.nextafter(0, 1))
         return information_content
 
     annotations_list = [terms_to_genes]

--- a/phenopy/ic.py
+++ b/phenopy/ic.py
@@ -4,26 +4,26 @@ import numpy as np
 SMOOTH = 1
 
 
-def calculate_information_content(hpo_id, hpo_network, terms_to_genes, a_count, custom_annotations):
+def calculate_information_content(hpo_id, hpo_network, terms_to_genes, num_genes_annotated, custom_annotations):
     """
     Calculates information content for an HPO term.
 
     :param hpo_id: HPO term to calculate information content for.
     :param hpo_network: HPO network.
     :param terms_to_genes: HPO terms to genes mapping dictionary.
-    :param a_count: Total count of HPO genes annotations.
+    :param num_genes_annotated: Number of genes with HPO annotations.
     :param custom_annotations: A list of dictionaries mapping HPO terms to custom annotations
     :return: `float`
     """
     # compile list of HPO terms to include in the calculation, term plus children
     hpo_id_plus_children = [hpo_id] + list(nx.ancestors(hpo_network, hpo_id))
-
+    # num_genes_annotated is
     def get_ic(hpo_ids, annotations):
-        # count hpo genes annotations related to this term and children
-        count_hpo_annos = sum([len(annotations[h]) for h in hpo_ids if h in annotations])
+        # count the number of unique genes annotated to the hpo term and it's children
+        n_unique_genes = len({g for h in hpo_ids if h in annotations for g in annotations[h]})
         # negative log of the number of hpo annotations divided by the total number of hpo terms in the
         # phenotypes_to_genes file
-        information_content = -np.log((count_hpo_annos + SMOOTH) / float(a_count + SMOOTH))
+        information_content = -np.log((n_unique_genes + SMOOTH) / float(num_genes_annotated + SMOOTH))
         # include this to avoid returning zero division warnings.
         # when comparing two different leaves whose LCA is "phenotypic abnormality", the right side of the equation:
         # alphaIC / (alphaIC / betaIC), would be 0.0 / (0.0 / 0.0)

--- a/phenopy/network.py
+++ b/phenopy/network.py
@@ -5,7 +5,7 @@ from phenopy.obo import cache, process, restore
 from phenopy.obo import load as load_obo
 
 
-def _load_hpo_network(obo_file, terms_to_genes, annotations_count, custom_annotations_file, hpo_network_file=None):
+def _load_hpo_network(obo_file, terms_to_genes, num_genes_annotated, custom_annotations_file, hpo_network_file=None):
     """
     Load and process phenotypes to genes and obo files if we don't have a processed network already.
     """
@@ -18,7 +18,7 @@ def _load_hpo_network(obo_file, terms_to_genes, annotations_count, custom_annota
         # load and process hpo network
         logger.info(f'Loading HPO OBO file: {obo_file}')
         hpo_network = load_obo(obo_file, logger=logger)
-        hpo_network = process(hpo_network, terms_to_genes, annotations_count, custom_annotations_file,
+        hpo_network = process(hpo_network, terms_to_genes, num_genes_annotated, custom_annotations_file,
                               logger=logger)
 
         # save a cache of the processed network

--- a/phenopy/obo.py
+++ b/phenopy/obo.py
@@ -26,7 +26,7 @@ def load(obo_file, logger=None):
         exit(1)
 
 
-def process(hpo_network, terms_to_genes, annotations_count, custom_annotations_file=None, logger=None):
+def process(hpo_network, terms_to_genes, num_genes_annotated, custom_annotations_file=None, logger=None):
     """
     Cleans the HPO network.
 
@@ -34,7 +34,7 @@ def process(hpo_network, terms_to_genes, annotations_count, custom_annotations_f
 
     :param hpo_network: `networkx.MultiDiGraph` to clean.
     :param terms_to_genes: Dictionary mapping HPO terms to genes.
-    :param annotations_count: Total number of terms annotations.
+    :param num_genes_annotated: Number of genes with HPO annotations.
     :param custom_annotations_file: A list of custom annotation files, in the same format as tests/data/test.score-product.txt
     :return: `networkx.MultiDiGraph`
     """
@@ -82,7 +82,7 @@ def process(hpo_network, terms_to_genes, annotations_count, custom_annotations_f
             node_id,
             hpo_network,
             terms_to_genes,
-            annotations_count,
+            num_genes_annotated,
             custom_annos,
         )
 

--- a/phenopy/p2g.py
+++ b/phenopy/p2g.py
@@ -9,7 +9,7 @@ def load(pheno2genes_file, logger=None):
 
     :param pheno2genes_file: Phenotypes to genes file.
     :param logger: Python `logging` logger instance.
-    :return: `dict` {hpo_term: [genes]}, `int` total count of annotations
+    :return: `dict` {hpo_term: [genes]}, `dict` {gene: [hpo_ids]}, `int` number of genes  annotations
     """
     try:
         df = pd.read_csv(
@@ -44,4 +44,4 @@ def load(pheno2genes_file, logger=None):
     genes_to_terms = {gene: annotations['hpo_id'].tolist(
     ) for gene, annotations in df.groupby('gene')}
 
-    return terms_to_genes, genes_to_terms, count
+    return terms_to_genes, genes_to_terms, len(genes_to_terms)

--- a/phenopy/score.py
+++ b/phenopy/score.py
@@ -40,7 +40,7 @@ class Scorer:
         common_parents = parents[0].intersection(
             parents[1])
         # lca node
-        return max(common_parents, key=lambda n: self.hpo_network.node[n]['depth'])
+        return max(common_parents, key=lambda n: self.hpo_network.node[n]['ic'])
 
     def generate_alternate_ids(self):
         """Create a key, value store of alternate terms to canonical terms."""

--- a/tests/data/phenotypes_to_genes.txt
+++ b/tests/data/phenotypes_to_genes.txt
@@ -2,6 +2,7 @@
 HP:0003270	Abdominal distention	672	BRCA1
 HP:0000549	Abnormal conjugate eye movement	5728	PTEN
 HP:0012372	Abnormal eye morphology	5728	PTEN
+HP:0012372	Abnormal eye morphology	8092	ALX1
 HP:0012373	Abnormal eye physiology	5728	PTEN
 HP:0000496	Abnormality of eye movement	5728	PTEN
 HP:0000478	Abnormality of the eye	5728	PTEN

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -15,25 +15,25 @@ class ScorerTestCase(unittest.TestCase):
         # load phenotypes to genes associations
         pheno2genes_file = os.path.join(
             cls.parent_dir, 'data/phenotypes_to_genes.txt')
-        cls.terms_to_genes, cls.genes_to_terms, cls.annotations_count = load_p2g(
+        cls.terms_to_genes, cls.genes_to_terms, cls.num_genes_annotated = load_p2g(
             pheno2genes_file)
 
         # load and process the network
         cls.obo_file = os.path.join(cls.parent_dir, 'data/hp.obo')
         cls.hpo_network = load_obo(cls.obo_file)
-        cls.hpo_network = process(cls.hpo_network, cls.terms_to_genes, cls.annotations_count,
+        cls.hpo_network = process(cls.hpo_network, cls.terms_to_genes, cls.num_genes_annotated,
                                   custom_annotations_file=None)
 
     def test_ic_p2g(self):
         """Calculate the information content of a phenotype"""
-        self.assertAlmostEqual(self.hpo_network.node['HP:0012372']['ic'], 1.38, 1)
+        self.assertAlmostEqual(self.hpo_network.node['HP:0012372']['ic'], 0.287, 1)
 
     def test_ic_custom(self):
         """Calculate the information content of a phenotype when multiple annotations are present"""
         custom_annotation_file = os.path.join(self.parent_dir, 'data/test.score-product.txt')
         hpo_network = load_obo(self.obo_file)
-        hpo_network = process(hpo_network, self.terms_to_genes, self.annotations_count,
+        hpo_network = process(hpo_network, self.terms_to_genes, self.num_genes_annotated,
                               custom_annotations_file=custom_annotation_file)
 
-        self.assertAlmostEqual(hpo_network.node['HP:0012372']['ic'], 1.93, 1)
+        self.assertAlmostEqual(hpo_network.node['HP:0012372']['ic'], 0.837, 1)
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -30,7 +30,7 @@ class NetworkTestCase(unittest.TestCase):
 
         # this is a cleaned version of the network, so it is not the same as test_obo.py
         self.assertEqual(len(hpo_network), 20)
-        self.assertAlmostEqual(hpo_network.node[self.hpo_id]['ic'], 2.48, 2)
+        self.assertAlmostEqual(hpo_network.node[self.hpo_id]['ic'], 1.386, 2)
 
     def test_load_custom(self):
         hpo_network = _load_hpo_network(self.obo_file, self.pheno2genes_file, self.annotations_count,
@@ -39,4 +39,4 @@ class NetworkTestCase(unittest.TestCase):
                                         hpo_network_file=self.hpo_network_file
                                         )
 
-        self.assertAlmostEqual(hpo_network.node[self.hpo_id]['ic'], 1.94, 2)
+        self.assertAlmostEqual(hpo_network.node[self.hpo_id]['ic'], 0.837, 2)

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -70,7 +70,7 @@ class ScorerTestCase(unittest.TestCase):
         t2 = 'HP:0012373'
 
         beta = self.scorer.calculate_beta(t1, t2)
-        self.assertAlmostEqual(beta, 0.89587, places=4)
+        self.assertAlmostEqual(beta, 0.2027, places=4)
 
     def test_score_hpo_pair_hrss(self):
         t1 = 'HP:0000501'
@@ -78,15 +78,15 @@ class ScorerTestCase(unittest.TestCase):
 
         # score two terms
         score = self.scorer.score_hpo_pair_hrss((t1, t2))
-        self.assertAlmostEqual(score, 0.4362, places=4)
+        self.assertAlmostEqual(score, 0.5, places=4)
 
         # test that the cache is working
         score = self.scorer.score_hpo_pair_hrss((t1, t2))
-        self.assertAlmostEqual(score, 0.4362, places=4)
+        self.assertAlmostEqual(score, 0.5, places=4)
 
         # and test that the cache is working for inverse comparisons
         score = self.scorer.score_hpo_pair_hrss((t2, t1))
-        self.assertAlmostEqual(score, 0.4362, places=4)
+        self.assertAlmostEqual(score, 0.5, places=4)
 
     def test_score(self):
         terms_a = ['HP:0000501', 'HP:0001087']
@@ -98,10 +98,10 @@ class ScorerTestCase(unittest.TestCase):
 
         # test BMA
         score_bma = self.scorer.score(terms_a, terms_b, agg_score='BMA')
-        self.assertAlmostEqual(score_bma, 0.1252, places=4)
+        self.assertAlmostEqual(score_bma, 0.2961, places=4)
 
         score_max = self.scorer.score(terms_a, terms_b, agg_score='maximum')
-        self.assertAlmostEqual(score_max, 0.1558, places=4)
+        self.assertAlmostEqual(score_max, 0.5, places=4)
 
     def test_no_parents(self):
         terms_a = ['HP:0000478', 'HP:0000501']


### PR DESCRIPTION
5398c0e  Converts the information content calculation to use the canonical definition in the HRSS paper.
Where `p(c) = number unique genes annotated to c / number of unique genes in the annotation corpus`, and where `c = HPO id`.

c423673 is a bugfix where an information content value of `np.isinf` is now converted to a large number instead of small number. (It's worth noting, we've never seen `np.isinf(information_content` evaluate `True`.

3be765a uses the canonical definition of the most informative common ancestor (MICA) instead of most recent common ancestor (MRCA). 
