### PR TITLE
Adds instructions for installation on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ cd phenopy
 python setup.py install
 ```
 
+**To complete installation on macOS please install lightgbm using brew**
+```bash
+brew install lightgbm
+```
+
+or by following macOS installation instructions from [lightgbm documentation](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#macos).
+
 ## Command Line Usage
 ### score
 `phenopy` is primarily used as a command line tool. An entity, as described here, is presented as a sample, gene, or


### PR DESCRIPTION
The `lightgbm` package installs without issue on linux (see likelihood tests in GitHub actions 👍🏼).
But, on macOS, users need to install `lightgbm` separately for `phenopy` to work. This PR adds instructions to the README.