### PR TITLE
chore: add ai-platform-engineering to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @GeneDx/ai-platform-engineering


### PR DESCRIPTION
Adding ai-platform-engineering as primary code owner for all paths